### PR TITLE
Question: All tiles are moved 1 position

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **Fork of [riebel/pixi-tiledmap](https://github.com/riebel/pixi-tiledmap)**, updated for Pixi.js >=5.0.0
 
+
 **⚠️ Some of the types are incorrect**
 
 Use [Tiled Map Editor](http://www.mapeditor.org/) maps with [pixi.js](https://www.npmjs.com/package/pixi.js).


### PR DESCRIPTION
Hi!
I can't open issues so i opened a PR.
I get to load the tiled map but It does look superbroken :s
![image](https://github.com/eioo/pixi-tiledmap/assets/29523682/8d567566-4756-4db3-b831-add2a0c591da)

Do you have any idea on why is it happening?

I've attached the scene in case that helps.

[lobby.zip](https://github.com/eioo/pixi-tiledmap/files/11714453/lobby.zip)

